### PR TITLE
Add support for --date flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a simple timezone visualizer.
 
 ```
 tz list
-tz [zones] [--24]
+tz [zones] [--date] [--24]
 
 examples:
   tz UTC
@@ -28,6 +28,9 @@ You can also set via envrionment variables:
 
 
 `TZ_24=true`
+
+
+`TZ_DATE=true`
 
 
 ![example](https://raw.githubusercontent.com/mmcquillan/tz/master/example.png)

--- a/tz.go
+++ b/tz.go
@@ -33,10 +33,10 @@ func main() {
 	var zones []zone
 
 	// capture input
-	match, _, values := matcher.Matcher("<bin> [zones] [--24]", strings.Join(os.Args, " "))
+	match, _, values := matcher.Matcher("<bin> [zones] [--date] [--24]", strings.Join(os.Args, " "))
 	if !match || values["zones"] == "help" {
 		fmt.Println("tz list")
-		fmt.Println("tz [zones] [--24]")
+		fmt.Println("tz [zones] [--date] [--24]")
 		fmt.Println("")
 		fmt.Println("examples:")
 		fmt.Println("  tz UTC")
@@ -49,12 +49,18 @@ func main() {
 	}
 
 	// set 24
-	block := 7
+	block := 8
 	format := "hha"
 	if os.Getenv("TZ_24") == "true" || values["24"] == "true" {
-		block = 5
+		block = 6
 		format = "H"
 	}
+
+        // set date
+        date := false
+        if os.Getenv("TZ_DATE") == "true" || values["date"] == "true" {
+                date = true
+        }
 
 	// set zones
 	if os.Getenv("TZ_ZONES") != "" {
@@ -102,7 +108,11 @@ func main() {
 			for i := -half + 1; i <= half; i++ {
 				t := n.Add(time.Second * time.Duration((i*3600)+offset))
 				if i == 0 {
-					now.Printf(" %s ", t.Format(joda.Format(format)))
+					if date{
+						now.Printf(" %s - %s ", t.Format(joda.Format("MM/dd")), t.Format(joda.Format(format)))
+					} else {
+						now.Printf(" %s ", t.Format(joda.Format(format)))
+					}
 				} else if t.Hour() >= z.start && t.Hour() <= z.end {
 					active.Printf(" %s ", t.Format(joda.Format(format)))
 				} else {


### PR DESCRIPTION
Add a `--date` flag to print the current month and day with the current time.

This could be helpful when comparing timezones with a big offset.

<img width="609" alt="screen shot 2018-06-21 at 11 03 17 am" src="https://user-images.githubusercontent.com/8949695/41731012-e6f05f22-7542-11e8-8bb3-bb3688629aac.png">
