### PR TITLE
Let command line zones take precedence over environment variables

### DIFF
--- a/tz.go
+++ b/tz.go
@@ -57,12 +57,12 @@ func main() {
 	}
 
 	// set zones
-	if os.Getenv("TZ_ZONES") != "" {
+	if values["zones"] != "" {
+                for _, tz := range strings.Split(values["zones"], ",") {
+                        zones = append(zones, splitInput(tz))
+                }
+	} else if os.Getenv("TZ_ZONES") != "" {
 		for _, tz := range strings.Split(os.Getenv("TZ_ZONES"), ",") {
-			zones = append(zones, splitInput(tz))
-		}
-	} else if values["zones"] != "" {
-		for _, tz := range strings.Split(values["zones"], ",") {
 			zones = append(zones, splitInput(tz))
 		}
 	} else {


### PR DESCRIPTION
I think it's more natural to let the command line arguments take precedence over the environment variables.

My use case for this is setting a `TZ_ZONES` variable in my `.bash_profile` so I always have my "defaults". But when I want to compare timezones that aren't in my defaults, I can overwrite that variables with the command line arguments.