### PR TITLE
Add shorthand zones

### DIFF
--- a/tz.go
+++ b/tz.go
@@ -168,9 +168,19 @@ func findOffset(tz string) (offset int, match bool) {
 	offset = 0
 	match = false
 
-	// cleanup
-	if strings.ToUpper(tz) == "LOCAL" {
+	// shorthand timezones
+	tz_shorthand := strings.ToUpper(tz)
+	switch tz_shorthand {
+	case "LOCAL":
 		tz = "Local"
+	case "EASTERN":
+		tz = "America/New_York"
+	case "CENTRAL":
+		tz = "America/Chicago"
+	case "MOUNTAIN":
+		tz = "America/Denver"
+	case "PACIFIC":
+		tz = "America/Los_Angeles"
 	}
 
 	// first, std timezone lib


### PR DESCRIPTION
Add shorthand names for the US timezones. This could make it easier and quicker to compare US timezones.

Timezone Shorthand Names:

```
Eastern => America/New_York
Central => America/Chicago
Mountain => America/Denver
Pacific => America/Los_Angeles
```

<img width="671" alt="image" src="https://user-images.githubusercontent.com/8949695/41731490-2b439d1e-7544-11e8-8878-b2b0f5efbf26.png">

