### PR TITLE
Handle undefined zone name

### DIFF
--- a/tz.go
+++ b/tz.go
@@ -157,6 +157,11 @@ func splitInput(input string) (z zone) {
 		}
 	}
 
+	// handle empty name
+	if z.name == "" {
+		z.name = z.tz
+	}
+
 	// return
 	return z
 


### PR DESCRIPTION
If someone passes a blank name for the zone, set its name to the timezone.

For example, currently if someone passed in: `tz UTC::8:17` the name would show up blank. Now when using the same command, it will set the name as the timezone.

<img width="634" alt="screen shot 2018-06-21 at 11 17 01 am" src="https://user-images.githubusercontent.com/8949695/41731692-a88a31ca-7544-11e8-921c-235a4d1d4d67.png">
