### PR TITLE
Add highlighting option to the name

### DIFF
--- a/tz.go
+++ b/tz.go
@@ -95,6 +95,7 @@ func main() {
 	active := color.New(color.BgGreen)
 	now := color.New(color.BgBlue)
 	nope := color.New(color.BgRed)
+  info := color.New(color.FgRed)
 
 	// set time
 	n := time.Now().UTC()
@@ -104,8 +105,12 @@ func main() {
 	for _, z := range zones {
 		offset, match := findOffset(z.tz)
 		if match {
-			fmt.Printf(" %s%s ", strings.Repeat(" ", name-len(z.name)), z.name)
-			for i := -half + 1; i <= half; i++ {
+      if z.highlight {
+				info.Printf(" %s%s ", strings.Repeat(" ", name-len(z.name)), z.name)
+			} else {
+				fmt.Printf(" %s%s ", strings.Repeat(" ", name-len(z.name)), z.name)
+			}
+      for i := -half + 1; i <= half; i++ {
 				t := n.Add(time.Second * time.Duration((i*3600)+offset))
 				if i == 0 {
 					if date{
@@ -140,6 +145,7 @@ func splitInput(input string) (z zone) {
 		name:  input,
 		start: 25,
 		end:   25,
+    highlight:  false,
 	}
 
 	// do we split
@@ -167,9 +173,9 @@ func splitInput(input string) (z zone) {
 		}
 	}
 
-	// handle empty name
-	if z.name == "" {
-		z.name = z.tz
+  if strings.HasPrefix(z.name, "@") {
+		z.name = strings.Replace(z.name, "@", "", -1)
+		z.highlight = true
 	}
 
 	// return
@@ -223,4 +229,5 @@ type zone struct {
 	name  string
 	start int
 	end   int
+  highlight  bool
 }

--- a/tz.go
+++ b/tz.go
@@ -95,7 +95,7 @@ func main() {
 	active := color.New(color.BgGreen)
 	now := color.New(color.BgBlue)
 	nope := color.New(color.BgRed)
-  info := color.New(color.FgRed)
+	info := color.New(color.FgRed)
 
 	// set time
 	n := time.Now().UTC()
@@ -105,12 +105,12 @@ func main() {
 	for _, z := range zones {
 		offset, match := findOffset(z.tz)
 		if match {
-      if z.highlight {
+			if z.highlight {
 				info.Printf(" %s%s ", strings.Repeat(" ", name-len(z.name)), z.name)
 			} else {
 				fmt.Printf(" %s%s ", strings.Repeat(" ", name-len(z.name)), z.name)
 			}
-      for i := -half + 1; i <= half; i++ {
+			for i := -half + 1; i <= half; i++ {
 				t := n.Add(time.Second * time.Duration((i*3600)+offset))
 				if i == 0 {
 					if date{
@@ -141,11 +141,11 @@ func splitInput(input string) (z zone) {
 
 	// default
 	z = zone{
-		tz:    input,
-		name:  input,
-		start: 25,
-		end:   25,
-    highlight:  false,
+		tz:        input,
+		name:      input,
+		start:     25,
+		end:       25,
+		highlight: false,
 	}
 
 	// do we split
@@ -173,7 +173,7 @@ func splitInput(input string) (z zone) {
 		}
 	}
 
-  if strings.HasPrefix(z.name, "@") {
+	if strings.HasPrefix(z.name, "@") {
 		z.name = strings.Replace(z.name, "@", "", -1)
 		z.highlight = true
 	}
@@ -225,9 +225,9 @@ func findOffset(tz string) (offset int, match bool) {
 }
 
 type zone struct {
-	tz    string
-	name  string
-	start int
-	end   int
-  highlight  bool
+	tz        string
+	name      string
+	start     int
+	end       int
+	highlight bool
 }


### PR DESCRIPTION
It could be helpful to add the capability to highlight a name of a timezone. Like highlighting your own name so it's easy to find yourself. To highlight a name, add a `@` right before the name. Like so:

```
tz UTC,America/New_York:@Graham:8:17,America/Chicago:Greg:8:17
```
<img width="663" alt="screen shot 2018-06-22 at 12 58 55 am" src="https://user-images.githubusercontent.com/8949695/41760169-b257e1e8-75b7-11e8-9783-374abf02b961.png">
